### PR TITLE
Implement full RAG cycle for response generation #20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ env:
   PROJECT_ID: rag-project-469718
   REGION: us-central1
   REPOSITORY: rag-app
+  IMAGE: rag-api
+  LABEL: v2
 
 jobs:
   # === Job 1: Run pre-commit checks ===
@@ -61,11 +63,11 @@ jobs:
 
       - name: 🏗️ Build Docker image
         run: |
-          docker build -t ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/api:${{ github.sha }} .
+          docker build -t ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{env.IMAGE}}:${{ env.LABEL }} .
 
       - name: 📤 Push to Artifact Registry
         run: |
-          docker push ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/api:${{ github.sha }}
+          docker push ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{env.IMAGE}}:${{ env.LABEL }}
 
   # === Job 3: Deploy to Cloud Run ===
   deploy:
@@ -82,4 +84,4 @@ jobs:
         with:
           service: rag-app
           region: ${{ env.REGION }}
-          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/api:v2
+          image: ${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.REPOSITORY }}/${{env.IMAGE}}:${{ env.LABEL }}

--- a/src/models/schemas.py
+++ b/src/models/schemas.py
@@ -24,12 +24,14 @@ class QueryResponse(BaseModel):
     Defines the structure of the response sent back to the user.
     """
 
-    final_prompt: str
+    answer: str
+    debug_prompt: str | None = None
 
     class Config:
         json_schema_extra = {
             "example": {
-                "final_prompt": "You are an expert sales assistant...\n\n**Product context found:**\nProduct: Sicons All Purpose Arnica Dog Shampoo...\n\n**Customer question:**\nI'm looking for a dog shampoo\n\n**Your answer:"
+                "answer": "Yes, we have the Sicons All Purpose Arnica Dog Shampoo. It's great for all dog breeds and has a pleasant arnica fragrance.",
+                "debug_prompt": "You are an expert sales assistant... **Recent conversation history:**\nHuman: Hi, my name is Alex.\nAI: Hello Alex! How can I help you today? ...",
             }
         }
 


### PR DESCRIPTION
This commit completes the RAG workflow by enabling the API to generate and return a final answer instead of just a prompt. #20

- A new  service function orchestrates the full cycle: retrieve, augment, and generate.
- The conversation memory now saves the actual user input and LLM output, allowing for coherent follow-up questions.
- The API endpoint is renamed to  and the response schema is updated to return a user-friendly .
- Adds an optional  to the response for easier debugging.